### PR TITLE
Fix cancellation of thumbnailer loop on input stream close

### DIFF
--- a/internal/inputs/rtmp/rtmp.go
+++ b/internal/inputs/rtmp/rtmp.go
@@ -208,9 +208,10 @@ func (h *connHandler) OnPublish(ctx *gortmp.StreamContext, timestamp uint32, cmd
 }
 
 func (h *connHandler) OnClose() {
-	h.log.Info("OnClose")
+	h.log.Info("RTMP OnClose")
 
 	h.stopMetadataCollection <- true
+	h.log.Debug("sent stop metadata collection signal")
 
 	// We only want to publish the stop if it's ours
 	// We also don't want control to stop the stream if we're respond to a stop

--- a/pkg/control/stream.go
+++ b/pkg/control/stream.go
@@ -1,6 +1,7 @@
 package control
 
 import (
+	"context"
 	"errors"
 
 	"github.com/Glimesh/waveguide/pkg/types"
@@ -17,6 +18,8 @@ type StreamTrack struct {
 
 type Stream struct {
 	log logrus.FieldLogger
+
+	cancelFunc context.CancelFunc
 
 	// authenticated is set after the stream has successfully authed with a remote service
 	authenticated bool
@@ -82,4 +85,16 @@ func (s *Stream) ReportMetadata(metadatas ...Metadata) error {
 	}
 
 	return nil
+}
+
+func (s *Stream) Stop() {
+	s.log.Infof("stopping stream")
+
+	s.stopHeartbeat <- struct{}{} // not being used anywhere, is it really needed?
+
+	s.stopThumbnailer <- struct{}{}
+	s.log.Debug("sent stop thumbnailer signal")
+
+	s.cancelFunc()
+	s.log.Debug("canceled stream ctx")
 }


### PR DESCRIPTION
This PR addresses a bug introduced with #20 for issue #16 where the `Peersnap(thumbnailer)` would not exit it's RTP read loop when input stream was stopped or closed. The issue seemed to appear when using OBS to stream on either RTMP or FTL protocols.

The fix required deriving a `contextWithCancel` from the parent `context` in control and invoking the cancel func in `control.StopStream`